### PR TITLE
feat: add method `subtractRound` to prevent date overflow

### DIFF
--- a/API.md
+++ b/API.md
@@ -29,6 +29,7 @@ Also inherit from Day.js, part of manipulations is immutable.
   - [Add `.add(int val, String unit)`](#add-addint-val-string-unit)
   - [Add Round `.addRound(int val, String unit)`](#add-round-addroundint-val-string-unit)
   - [Subtract `.subtract(int val, String unit)`](#subtract-subtractint-val-string-unit)
+  - [Subtract Round `.subtractRound(int val, String unit)`](#subtract-round-subtractroundint-val-string-unit)
   - [Inc (Same as add)](#inc-same-as-add)
   - [Dec (Same as subtract)](#dec-same-as-subtract)
 - [Displaying](#displaying)
@@ -309,10 +310,25 @@ d.addRound(1, 'month'); // 2022-04-30T15:52:50.000Z
 
 Returns a cloned day with a specified amount of time subtracted.
 
+So if you wanna receive a non-overflow date, you should use `.subtractRound()` method below.
+
+Refer to [`.add()`](#add-addint-val-string-unit) for more details.
+
 ```dart
 final d = Day();
 
 d.subtract(1, 'date');
+```
+
+### Subtract Round `.subtractRound(int val, String unit)`
+
+Returns a cloned day with a specified amount of time subtracted but rounded to the last day of the current month if overflowed.
+
+```dart
+final d = Day.fromString('2022-03-31T15:52:50.000Z');
+
+d.subtract(1, 'month'); // 2022-03-03T15:52:50.000Z
+d.subtractRound(1, 'month'); // 2022-02-28T15:52:50.000Z
 ```
 
 ### Inc (Same as add)

--- a/lib/src/day.dart
+++ b/lib/src/day.dart
@@ -331,6 +331,7 @@ class Day {
   Day? _add({
     required int val,
     required String unit,
+    bool opposite = false,
     bool rounded = false,
   }) {
     final processedUnit = Unit.fromShorthand(unit);
@@ -339,13 +340,13 @@ class Day {
     if (duration != null) {
       final d = clone();
 
-      d._time = d._time.add(duration);
+      d._time = !opposite ? d._time.add(duration) : d._time.subtract(duration);
       d._parseTime();
 
       return d;
     } else {
       if (unit == Unit.y || unit == 'y') {
-        final currentYear = year() + val;
+        final currentYear = year() + (!opposite ? val : -val);
 
         if (rounded) {
           final currentMonth = month();
@@ -364,7 +365,7 @@ class Day {
       } else if (unit == Unit.m || unit == 'M') {
         final d = clone();
 
-        final int result = month() + val;
+        final int result = month() + (!opposite ? val : -val);
 
         if (result > 0) {
           d.setValue(Unit.m, result);
@@ -423,39 +424,11 @@ class Day {
   /// subtract(1, 'date');
   /// subtract(1, 'd');
   /// ```
-  dynamic subtract(int val, String unit) {
-    final processedUnit = Unit.fromShorthand(unit);
-    final duration = u.durationFromUnit(val, processedUnit);
+  Day? subtract(int val, String unit) =>
+      _add(val: val, unit: unit, opposite: true);
 
-    if (duration != null) {
-      final d = clone();
-
-      d._time = d._time.subtract(duration);
-      d._parseTime();
-
-      return d;
-    } else {
-      if (unit == Unit.y || unit == 'y') {
-        return _cloneAndSetSingleValue(Unit.y, year() - val);
-      } else if (unit == Unit.m || unit == 'M') {
-        final int result = month() - val;
-
-        final d = clone();
-        if (result > 0) {
-          d.setValue(Unit.m, result);
-        } else {
-          d
-            ..setValue(Unit.y, d.year() - (result.abs() ~/ 12 + 1))
-            ..setValue(Unit.m, 12 - result.abs() % 12);
-        }
-        d.finished();
-
-        return d;
-      }
-    }
-
-    return null;
-  }
+  Day? subtractRound(int val, String unit) =>
+      _add(val: val, unit: unit, opposite: true, rounded: true);
 
   /// Alias of [add].
   dynamic inc(int val, String unit) => add(val, unit);

--- a/test/day_subtract_round_test.dart
+++ b/test/day_subtract_round_test.dart
@@ -1,0 +1,22 @@
+import 'package:test/test.dart';
+import 'package:day/day.dart';
+
+void main() {
+  test(
+      '.subtractRound(1, \'M\') returns a date not exceeding the current month',
+      () {
+    final d = Day.fromString('2022-03-31T15:52:50.000Z').subtractRound(1, 'M')!;
+
+    expect(d.month(), equals(2));
+    expect(d.date(), 28);
+  });
+
+  test(
+      '.subtractRound(1, \'y\') returns a date not exceeding the current month',
+      () {
+    final d = Day.fromString('2020-02-29T15:52:50.000Z').subtractRound(1, 'y')!;
+
+    expect(d.month(), equals(2));
+    expect(d.date(), 28);
+  });
+}

--- a/test/day_subtract_test.dart
+++ b/test/day_subtract_test.dart
@@ -6,7 +6,7 @@ void main() {
 
   group('Subtract Method:', () {
     test('1 year', () {
-      final Day dClone = d.subtract(1, 'year');
+      final dClone = d.subtract(1, 'year')!;
 
       expect(d.year(), equals(2019));
 
@@ -14,7 +14,7 @@ void main() {
     });
 
     test('-1 year', () {
-      final Day dClone = d.subtract(-1, 'year');
+      final dClone = d.subtract(-1, 'year')!;
 
       expect(d.year(), equals(2019));
 
@@ -22,7 +22,7 @@ void main() {
     });
 
     test('2 months', () {
-      final Day dClone = d.subtract(2, 'month');
+      final dClone = d.subtract(2, 'month')!;
 
       expect(d.month(), equals(4));
 
@@ -30,7 +30,7 @@ void main() {
     });
 
     test('4 months', () {
-      final Day dClone = d.subtract(4, 'month');
+      final dClone = d.subtract(4, 'month')!;
 
       expect(d.year(), equals(2019));
       expect(d.month(), equals(4));
@@ -40,7 +40,7 @@ void main() {
     });
 
     test('28 months', () {
-      final Day dClone = d.subtract(28, 'month');
+      final dClone = d.subtract(28, 'month')!;
 
       expect(d.year(), equals(2019));
       expect(d.month(), equals(4));
@@ -50,7 +50,7 @@ void main() {
     });
 
     test('-8 months', () {
-      final Day dClone = d.subtract(-8, 'month');
+      final dClone = d.subtract(-8, 'month')!;
 
       expect(d.year(), equals(2019));
       expect(d.month(), equals(4));
@@ -60,7 +60,7 @@ void main() {
     });
 
     test('-9 months', () {
-      final Day dClone = d.subtract(-9, 'month');
+      final dClone = d.subtract(-9, 'month')!;
 
       expect(d.year(), equals(2019));
       expect(d.month(), equals(4));
@@ -70,7 +70,7 @@ void main() {
     });
 
     test('1 day', () {
-      final Day dClone = d.subtract(1, 'date');
+      final dClone = d.subtract(1, 'date')!;
 
       expect(d.month(), equals(4));
       expect(d.date(), equals(30));
@@ -80,7 +80,7 @@ void main() {
     });
 
     test('1 hour', () {
-      final Day dClone = d.subtract(1, 'hour');
+      final dClone = d.subtract(1, 'hour')!;
 
       expect(d.hour(), equals(10));
 
@@ -88,7 +88,7 @@ void main() {
     });
 
     test('-1 hour', () {
-      final Day dClone = d.subtract(-1, 'hour');
+      final dClone = d.subtract(-1, 'hour')!;
 
       expect(d.hour(), equals(10));
 
@@ -96,7 +96,7 @@ void main() {
     });
 
     test('1 minute', () {
-      final Day dClone = d.subtract(1, 'minute');
+      final dClone = d.subtract(1, 'minute')!;
 
       expect(d.minute(), equals(30));
 
@@ -104,7 +104,7 @@ void main() {
     });
 
     test('-1 minute', () {
-      final Day dClone = d.subtract(-1, 'minute');
+      final dClone = d.subtract(-1, 'minute')!;
 
       expect(d.minute(), equals(30));
 
@@ -112,7 +112,7 @@ void main() {
     });
 
     test('1 second', () {
-      final Day dClone = d.subtract(1, 'second');
+      final dClone = d.subtract(1, 'second')!;
 
       expect(d.second(), equals(30));
 
@@ -120,7 +120,7 @@ void main() {
     });
 
     test('-1 second', () {
-      final Day dClone = d.subtract(-1, 'second');
+      final dClone = d.subtract(-1, 'second')!;
 
       expect(d.second(), equals(30));
 
@@ -128,7 +128,7 @@ void main() {
     });
 
     test('1 ms', () {
-      final Day dClone = d.subtract(1, 'ms');
+      final dClone = d.subtract(1, 'ms')!;
 
       expect(d.millisecond(), equals(0));
 
@@ -136,7 +136,7 @@ void main() {
     });
 
     test('-1 ms', () {
-      final Day dClone = d.subtract(-1, 'ms');
+      final dClone = d.subtract(-1, 'ms')!;
 
       expect(d.millisecond(), equals(0));
 


### PR DESCRIPTION
Other changes:

- Now `.subtract()` returns nullable
- Refactor `.subtract()` by re-using internal `._add()` method
